### PR TITLE
fix: query failing if variable value is an array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airstack/airstack-react",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/lib/utils/stringifyObjectValues.ts
+++ b/src/lib/utils/stringifyObjectValues.ts
@@ -1,10 +1,16 @@
-export function stringifyObjectValues(obj: Record<string, any>) {
+export function stringifyObjectValues(value: Record<string, any>) {
   const stringified: Record<string, string> = {};
-  for (const key in obj) {
-    if (typeof obj[key] === "object") {
-      stringified[key] = JSON.stringify(obj[key]);
+  if (!value || typeof value !== "object") return value;
+
+  for (const key in value) {
+    if (Array.isArray(value[key])) {
+      stringified[key] = value[key].map((item: any) =>
+        stringifyObjectValues(item)
+      );
+    } else if (typeof value[key] === "object") {
+      stringified[key] = JSON.stringify(value[key]);
     } else {
-      stringified[key] = obj[key];
+      stringified[key] = value[key];
     }
   }
   return stringified;


### PR DESCRIPTION
Fix - Query was failing if any of the variables value is of type array
Minor version bump