### PR TITLE
Fix: no re-rendering on refetch, add missing types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airstack/airstack-react",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/lib/apis/fetchPaginatedQuery.ts
+++ b/src/lib/apis/fetchPaginatedQuery.ts
@@ -55,6 +55,9 @@ export async function fetchPaginatedQuery(
         cacheResponse(response, _query, variables);
       }
       cacheImagesFromQuery(data);
+    } else {
+      // return a new reference to the data object, so reference equality check in React components/hooks will work
+      data = { ...data };
     }
 
     paginationData = getPaginationData(data);

--- a/src/lib/apis/fetchQuery.ts
+++ b/src/lib/apis/fetchQuery.ts
@@ -32,6 +32,9 @@ export async function fetchQuery(
       cacheResponse(response, query, _variables);
     }
     cacheImagesFromQuery(data);
+  } else {
+    // return a new reference to the data object, so reference equality check in React components/hooks will work
+    data = { ...data };
   }
 
   return {

--- a/src/lib/components/Asset/Media.tsx
+++ b/src/lib/components/Asset/Media.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  ComponentProps,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { PresetImageSize } from "../../constants";
 import { NFTAssetURL } from "../../types";
 import { MediaType, getMediaType, getMediaTypeFromUrl } from "./utils";
@@ -8,10 +14,8 @@ import styles from "./styles.module.css";
 
 // !!! TODO: handle html, svg markup (SENITISE markup)
 
-type HTMLVideoProps = React.DetailedHTMLProps<
-  React.ImgHTMLAttributes<HTMLVideoElement>,
-  HTMLVideoElement
->;
+type HTMLVideoProps = ComponentProps<"video">;
+type HTMLAudioProps = ComponentProps<"audio">;
 
 export type MediaProps = {
   imgProps?: React.DetailedHTMLProps<
@@ -22,10 +26,7 @@ export type MediaProps = {
     // max duration in seconds, if videos are shorter than this, they will be auto played, default 10 seconds
     maxDurationForAutoPlay?: number;
   } & HTMLVideoProps;
-  audioProps?: React.DetailedHTMLProps<
-    React.ImgHTMLAttributes<HTMLAudioElement>,
-    HTMLAudioElement
-  >;
+  audioProps?: HTMLAudioProps;
   preset: PresetImageSize;
   data?: NFTAssetURL["value"];
   onError: () => void;


### PR DESCRIPTION
 - Fix react components does not re-render on the prefetching same query, as the cache data reference is the same
 - Fix in asset component video and audio props are missing
 - Minor version bump to 0.4.4