### PR TITLE
Add config provider and bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airstack/airstack-react",
-  "version": "0.4.5",
+  "version": "0.4.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,4 @@
-type Env = "dev" | "prod";
+export type Env = "dev" | "prod";
 export type Config = {
   authKey: string;
   env?: Env;

--- a/src/lib/hooks/useQueryWithPagination.ts
+++ b/src/lib/hooks/useQueryWithPagination.ts
@@ -46,6 +46,16 @@ export function useLazyQueryWithPagination(
   const prevRef = useRef<null | (() => Promise<FetchQuery | null>)>(null);
   const variablesRef = useRef<Variables>(variables || {});
 
+  const reset = useCallback(() => {
+    nextRef.current = null;
+    prevRef.current = null;
+    setData(null);
+    setError(null);
+    setLoading(false);
+    setHasNextPage(false);
+    setHasPrevPage(false);
+  }, [setData, setError, setLoading]);
+
   const handleResponse = useCallback(
     (res: null | Awaited<FetchPaginatedQueryReturnType>) => {
       if (!res) return;
@@ -70,7 +80,7 @@ export function useLazyQueryWithPagination(
 
   const fetch: FetchType = useCallback(
     async (_variables?: Variables) => {
-      setError(null);
+      reset();
       setLoading(true);
 
       const queryWithPagination = await addPaginationToQuery(query);
@@ -91,7 +101,7 @@ export function useLazyQueryWithPagination(
         },
       };
     },
-    [configRef, handleResponse, query, setError, setLoading]
+    [configRef, handleResponse, query, reset, setLoading]
   );
 
   const getNextPage = useCallback(async () => {

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { Config } from "./config";
+import { init } from "./init";
+
+type ProviderProps = {
+    apiKey: string;
+    children: JSX.Element;
+} & Omit<Config, "authKey">;
+
+export function AirstackProvider({ children, apiKey, ...config }: ProviderProps) {
+
+    useEffect(() => {
+        init(apiKey, config)
+    }, [apiKey, config])
+
+    return children
+}


### PR DESCRIPTION
- Added config provider support, now config can be passed through the provider instead of the init method
- Fixes: when removing part of a query (because of lack of next pages), if the query variable is of type array, it was not getting removed, so the query was failing
- Reset hook's all the internal states on fetch again
- Version Update to 0.4.7
