### PR TITLE
Fix/unable to import provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airstack/airstack-react",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/lib/components/Asset/utils.ts
+++ b/src/lib/components/Asset/utils.ts
@@ -53,6 +53,8 @@ export function getPreset(el?: HTMLElement | null) {
 }
 
 export async function getMediaTypeFromUrl(url: string) {
+  if (!url) return "unknown";
+
   const response = await fetch(url, {
     method: "HEAD",
   });

--- a/src/lib/components/Asset/utils.ts
+++ b/src/lib/components/Asset/utils.ts
@@ -53,7 +53,9 @@ export function getPreset(el?: HTMLElement | null) {
 }
 
 export async function getMediaTypeFromUrl(url: string) {
-  if (!url) return "unknown";
+  if (!url) {
+    return "unknown";
+  }
 
   const response = await fetch(url, {
     method: "HEAD",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,3 +2,4 @@ export * from "./apis";
 export * from "./init";
 export * from "./hooks";
 export * from "./components";
+export * from "./provider";


### PR DESCRIPTION
- Added missing export of provider
- Error handling: if there is no URL to fetch asset media type, return unknown without making any API call
- Updated the package version to 0.5.2