### PR TITLE
Fix error when loading an image which has a different variant than in data

### DIFF
--- a/src/lib/components/Asset/Media.tsx
+++ b/src/lib/components/Asset/Media.tsx
@@ -13,7 +13,7 @@ import { MediaType, getMediaType, getMediaTypeFromUrl } from "./utils";
 import styles from "./styles.module.css";
 import { logError } from "../../utils/log";
 
-// !!! TODO: handle html, svg markup (SENITISE markup)
+// !!! TODO: handle html, svg markup (SANITIZE markup)
 
 type HTMLVideoProps = ComponentProps<"video">;
 type HTMLAudioProps = ComponentProps<"audio">;
@@ -32,9 +32,13 @@ export type MediaProps = {
   data?: NFTAssetURL["value"];
   onError: () => void;
   onComplete: () => void;
+  url: string | null;
 };
 
-type AudioVideoProps = Omit<MediaProps, "data" | "preset" | "onComplete"> & {
+type AudioVideoProps = Omit<
+  MediaProps,
+  "data" | "preset" | "onComplete" | "url"
+> & {
   url: string;
 };
 
@@ -100,30 +104,17 @@ function Video({ url, videoProps: elementProps, onError }: AudioVideoProps) {
     </video>
   );
 }
-
 export function Media({
-  data,
   preset,
   imgProps,
   videoProps,
   audioProps,
   onError,
   onComplete,
-}: Omit<MediaProps, "url">) {
+  url,
+}: MediaProps) {
   const [mediaType, setMediaType] = useState<MediaType | null>(null);
   const isLoadingRef = useRef(false);
-
-  let url: string | null = null;
-
-  if (data) {
-    // use animation url if available, otherwise use video, audio, or image
-    url =
-      data.animation_url?.original ||
-      data.video ||
-      data.audio ||
-      (data.image || {})[preset] ||
-      "";
-  }
 
   const handleUrlWithoutExtension = useCallback(
     async (url: string) => {
@@ -164,7 +155,7 @@ export function Media({
       logError("url is null");
       onError();
     }
-  }, [data, mediaType, onError, preset, url]);
+  }, [mediaType, onError, preset, url]);
 
   if (!mediaType || !url) return null;
 

--- a/src/lib/components/Asset/fetchNFTAssetURL.tsx
+++ b/src/lib/components/Asset/fetchNFTAssetURL.tsx
@@ -26,7 +26,8 @@ export interface AirstackAssetContextInterface {
 export const fetchNFTAssetURL = (
   chain: Chain,
   address: string,
-  tokenId: string
+  tokenId: string,
+  forceFetch = false
 ): Promise<NFTAssetURL> => {
   return new Promise((resolve, reject) => {
     if (address.length === 0) {
@@ -40,7 +41,7 @@ export const fetchNFTAssetURL = (
     }
 
     const nftAssetURL = getFromAssetCache(chain, address, tokenId);
-    if (nftAssetURL) {
+    if (!forceFetch && nftAssetURL) {
       //cache hit
       resolve(nftAssetURL);
     } else {

--- a/src/lib/components/Asset/utils.ts
+++ b/src/lib/components/Asset/utils.ts
@@ -1,4 +1,5 @@
-import { PresetArray, PresetPXSize } from "../../constants";
+import { PresetArray, PresetImageSize, PresetPXSize } from "../../constants";
+import { NFTAssetURL } from "../../types";
 
 export type MediaType = "image" | "video" | "audio" | "unknown";
 
@@ -76,4 +77,23 @@ export async function getMediaTypeFromUrl(url: string) {
   }
 
   return "unknown";
+}
+
+export function getUrlFromData({
+  data,
+  preset,
+}: {
+  data?: NFTAssetURL["value"] | null;
+  preset: PresetImageSize;
+}) {
+  if (!data) return null;
+
+  // use animation url if available, otherwise use video, audio, or image
+  return (
+    data.animation_url?.original ||
+    data.video ||
+    data.audio ||
+    (data.image || {})[preset] ||
+    ""
+  );
 }


### PR DESCRIPTION
**Issue: if some query data already had one image variant, then image load will fail when using the Asset component to fetch another variant of the same image.**