### PR TITLE
When using useQuery with the AirstackProvider,  the SDK is throwing no API key is provided error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airstack/airstack-react",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -1,17 +1,18 @@
-import { useEffect } from "react";
 import { Config } from "./config";
 import { init } from "./init";
 
 type ProviderProps = {
-    apiKey: string;
-    children: JSX.Element;
+  apiKey: string;
+  children: JSX.Element;
 } & Omit<Config, "authKey">;
 
-export function AirstackProvider({ children, apiKey, ...config }: ProviderProps) {
-
-    useEffect(() => {
-        init(apiKey, config)
-    }, [apiKey, config])
-
-    return children
+export function AirstackProvider({
+  children,
+  apiKey,
+  ...config
+}: ProviderProps) {
+  // don't call init inside an effect as the child components/hooks effects will get called before this one
+  // and the child components/hooks will not have access to the apiKey
+  init(apiKey, config);
+  return children;
 }


### PR DESCRIPTION
Issue: 
When using `useQuery` with the `AirstackProvider`,  the SDK is throwing an error **no API key is provided**

Fix: 
This happened because the API key was set within an effect triggered by the AirstackProvider. Since the AirstackProvider is positioned at the top of the component tree and its effect is executed after the effects of its child components or hooks, the useQuery function, which initiates an immediate API call, lacks access to the API key until the AirstackProvider's effect is invoked.

**So now we set the API key on the render of AirstackProvider**